### PR TITLE
Suggest ext-exif

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "squizlabs/php_codesniffer": "1.4.*@stable"
     },
     "suggest": {
-        "lib-exiftool": "Use perl lib exiftool as adapter"
+        "lib-exiftool": "Use perl lib exiftool as adapter",
+        "ext-exif": "Use exif PHP extension as adapter"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Can be tested locally using project with `composer.json` like this:

```
{
	"name": "tomasfejfar/composer-test",
	"repositories": [{
		"type": "vcs",
		"url": "w:\\git\\php-exif" <------- your path here
	}],
	"require": {
		"miljar/php-exif": "dev-dev/suggest-ext-exif" <---- your local branch here
	}
}
```
Resulting in 
```
Loading composer repositories with package information
Updating dependencies (including require-dev)
  - Installing miljar/php-exif (dev-dev/suggest-ext-exif eda189b)
    Cloning eda189b6608db5ecfc8c2624bebfb9c895e02c6c

miljar/php-exif suggests installing lib-exiftool (Use perl lib exiftool as adapter)
miljar/php-exif suggests installing ext-exif (Use exif PHP extension as adapter) <------- suggestion
Writing lock file
Generating autoload files
```
Fixes #59 