### PR TITLE
[field mapping] first letter case insensibility

### DIFF
--- a/lib/PHPExif/Mapper/Native.php
+++ b/lib/PHPExif/Mapper/Native.php
@@ -133,7 +133,7 @@ class Native implements MapperInterface
                 continue;
             }
 
-            if (!array_key_exists($field, $this->map)) {
+            if (!$this->isFieldKnown($field)) {
                 // silently ignore unknown fields
                 continue;
             }
@@ -212,6 +212,33 @@ class Native implements MapperInterface
     protected function isSection($field)
     {
         return (in_array($field, $this->sections));
+    }
+
+    /**
+     * Determines if the given field is known,
+     * in a case insensitive way for its first letter.
+     * Also update $field to keep it valid against the known fields.
+     *
+     * @param  string  &$field
+     * @return bool
+     */
+    protected function isFieldKnown(&$field)
+    {
+        $lcfField = lcfirst($field);
+        if (array_key_exists($lcfField, $this->map)) {
+            $field = $lcfField;
+
+            return true;
+        }
+
+        $ucfField = ucfirst($field);
+        if (array_key_exists($ucfField, $this->map)) {
+            $field = $ucfField;
+
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/tests/PHPExif/Mapper/NativeMapperTest.php
+++ b/tests/PHPExif/Mapper/NativeMapperTest.php
@@ -195,6 +195,27 @@ class NativeMapperTest extends \PHPUnit_Framework_TestCase
      * @group mapper
      * @covers \PHPExif\Mapper\Native::mapRawData
      */
+    public function testMapRawDataMacthesFieldsWithoutCaseSensibilityOnFirstLetter()
+    {
+        $rawData = array(
+            \PHPExif\Mapper\Native::ORIENTATION => 'Portrait',
+            'Copyright' => 'Acme',
+        );
+        $mapped = $this->mapper->mapRawData($rawData);
+        $this->assertCount(2, $mapped);
+        $keys = array_keys($mapped);
+
+        $expected = array(
+            \PHPExif\Mapper\Native::ORIENTATION,
+            \PHPExif\Mapper\Native::COPYRIGHT
+        );
+        $this->assertEquals($expected, $keys);
+    }
+
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\Native::mapRawData
+     */
     public function testMapRawDataCorrectlyFormatsGPSData()
     {
         $expected = array(


### PR DESCRIPTION
Hello,

This PR adds a case insensibility for the first letter of fields to the native mapper.

I have an image where the exif copyright is stored at `COMPUTED.Copyright` key, but the mapper was not able to retrieve it because it was looking for the `COMPUTED.copyright` key.

These changes permit the access to both keys.