### PR TITLE
Fix Division By Zero Warning for Focal Length

### DIFF
--- a/lib/PHPExif/Mapper/Native.php
+++ b/lib/PHPExif/Mapper/Native.php
@@ -165,7 +165,12 @@ class Native implements MapperInterface
                     break;
                 case self::FOCALLENGTH:
                     $parts = explode('/', $value);
-                    $value = (int) reset($parts) / (int) end($parts);
+                    // Avoid division by zero if focal length is invalid
+                    if (end($parts) == '0') {
+                        $value = 0;
+                    } else {
+                        $value = (int) reset($parts) / (int) end($parts);
+                    }
                     break;
                 case self::XRESOLUTION:
                 case self::YRESOLUTION:

--- a/tests/PHPExif/Mapper/NativeMapperTest.php
+++ b/tests/PHPExif/Mapper/NativeMapperTest.php
@@ -142,6 +142,21 @@ class NativeMapperTest extends \PHPUnit_Framework_TestCase
      * @group mapper
      * @covers \PHPExif\Mapper\Native::mapRawData
      */
+    public function testMapRawDataCorrectlyFormatsFocalLengthDivisionByZero()
+    {
+        $rawData = array(
+            \PHPExif\Mapper\Native::FOCALLENGTH => '1/0',
+        );
+
+        $mapped = $this->mapper->mapRawData($rawData);
+
+        $this->assertEquals(0, reset($mapped));
+    }
+
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\Native::mapRawData
+     */
     public function testMapRawDataCorrectlyFormatsXResolution()
     {
         $rawData = array(


### PR DESCRIPTION
If a file has invalid EXIF data, it can cause an division by zero warning to occur.